### PR TITLE
Add multi-model voting client

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ With the Gemini CLI you can:
   Veo or Lyria](https://github.com/GoogleCloudPlatform/vertex-ai-creative-studio/tree/main/experiments/mcp-genmedia)
 - Ground your queries with the [Google Search](https://ai.google.dev/gemini-api/docs/grounding)
   tool, built into Gemini.
+- Combine responses from multiple models (Gemini, Qwen, Kimi) and let a small model vote on the best answer.
 
 ## Quickstart
 
@@ -87,6 +88,17 @@ The Vertex AI API provides a [free tier](https://cloud.google.com/vertex-ai/gene
    ```bash
    export GOOGLE_API_KEY="YOUR_API_KEY"
    export GOOGLE_GENAI_USE_VERTEXAI=true
+   ```
+
+### Use an OpenRouter API key:
+
+This enables optional multi-model support through the `models` configuration.
+
+1. Sign up at [OpenRouter](https://openrouter.ai) and copy your API key.
+2. Set it as an environment variable:
+
+   ```bash
+   export OPENROUTER_API_KEY="YOUR_OPENROUTER_KEY"
    ```
 
 3. (Optionally) Add a billing account on your project to get access to [higher usage limits](https://cloud.google.com/vertex-ai/generative-ai/docs/quotas)

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -72,6 +72,10 @@ In addition to a project settings file, a project's `.gemini` directory can cont
   - **Description:** Allows you to specify a list of core tool names that should be made available to the model. This can be used to restrict the set of built-in tools. See [Built-in Tools](../core/tools-api.md#built-in-tools) for a list of core tools. You can also specify command-specific restrictions for tools that support it, like the `ShellTool`. For example, `"coreTools": ["ShellTool(ls -l)"]` will only allow the `ls -l` command to be executed.
   - **Default:** All tools available for use by the Gemini model.
   - **Example:** `"coreTools": ["ReadFileTool", "GlobTool", "ShellTool(ls)"]`.
+- **`models`** (array of strings):
+  - **Description:** Configure multiple models to answer a prompt in parallel. When set, each model is invoked concurrently and a small model chooses the best response.
+  - **Default:** `["gemini-2.5-pro"]`
+  - **Example:** `"models": ["gemini-2.5-flash", "qwen/qwen3-coder", "moonshotai/kimi-k2"]`
 
 - **`excludeTools`** (array of strings):
   - **Description:** Allows you to specify a list of core tool names that should be excluded from the model. A tool listed in both `excludeTools` and `coreTools` is excluded. You can also specify command-specific restrictions for tools that support it, like the `ShellTool`. For example, `"excludeTools": ["ShellTool(rm -rf)"]` will block the `rm -rf` command.
@@ -296,6 +300,10 @@ The CLI automatically loads environment variables from an `.env` file. The loadi
   - Specifies the default Gemini model to use.
   - Overrides the hardcoded default
   - Example: `export GEMINI_MODEL="gemini-2.5-flash"`
+- **`OPENROUTER_API_KEY`**:
+  - API key for [OpenRouter](https://openrouter.ai). Required when using
+    additional models through the `models` configuration.
+  - Example: `export OPENROUTER_API_KEY="YOUR_OPENROUTER_KEY"`
 - **`GOOGLE_API_KEY`**:
   - Your Google Cloud API key.
   - Required for using Vertex AI in express mode.

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -49,6 +49,13 @@ export async function runNonInteractive(
   prompt_id: string,
 ): Promise<void> {
   await config.initialize();
+
+  const multi = config.getMultiModelClient();
+  if (multi) {
+    const text = await multi.generate(input);
+    if (text) console.log(text);
+    return;
+  }
   // Handle EPIPE errors when the output is piped to a command that closes early.
   process.stdout.on('error', (err: NodeJS.ErrnoException) => {
     if (err.code === 'EPIPE') {

--- a/packages/core/src/core/multiModelClient.test.ts
+++ b/packages/core/src/core/multiModelClient.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MultiModelClient, LLMClient } from './multiModelClient.js';
+import { Config } from '../config/config.js';
+
+class FakeClient implements LLMClient {
+  constructor(public name: string, private reply: string) {}
+  async generate(): Promise<string> {
+    return this.reply;
+  }
+}
+
+describe('MultiModelClient', () => {
+  it('selects the longest response when no voter is available', async () => {
+    const config = new Config({
+      sessionId: 's',
+      targetDir: '.',
+      debugMode: false,
+      cwd: '.',
+      model: 'gemini-2.5-flash',
+      models: ['gemini-2.5-flash', 'other'],
+    } as never);
+    const client = new MultiModelClient(config);
+    // Replace clients with fakes
+    // @ts-expect-error accessing private field for test
+    client.clients = [new FakeClient('a', 'short'), new FakeClient('b', 'much longer text')];
+    const res = await client.generate('hi');
+    expect(res).toBe('much longer text');
+  });
+});

--- a/packages/core/src/core/multiModelClient.ts
+++ b/packages/core/src/core/multiModelClient.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Config } from '../config/config.js';
+import { GeminiClient } from './client.js';
+import { OpenRouterClient } from './openRouterClient.js';
+
+export interface LLMClient {
+  generate(prompt: string): Promise<string>;
+  name: string;
+}
+
+/**
+ * MultiModelClient dispatches the same prompt to multiple models in parallel
+ * and returns the response chosen by a secondary voting model. If no voting
+ * model is available, the longest response is used.
+ */
+export class MultiModelClient {
+  private clients: LLMClient[] = [];
+  private voter: LLMClient | null = null;
+
+  constructor(private config: Config) {
+    const apiKey = process.env.OPENROUTER_API_KEY;
+    for (const model of config.getModels()) {
+      if (model.startsWith('gemini')) {
+        this.clients.push({
+          name: model,
+          generate: async (prompt: string) => {
+            config.setModel(model);
+            const chat = await config.getGeminiClient().getChat();
+            const resp = await chat.sendMessage([ { text: prompt } ]);
+            return resp.candidates?.[0]?.content?.parts?.map(p => p.text).join('') || '';
+          },
+        });
+      } else if (apiKey) {
+        this.clients.push(new OpenRouterClient(apiKey, model));
+      }
+    }
+
+    if (apiKey) {
+      this.voter = new OpenRouterClient(apiKey, 'gpt-3.5-turbo');
+    }
+  }
+
+  async generate(prompt: string): Promise<string> {
+    const responses = await Promise.all(
+      this.clients.map((c) => c.generate(prompt)),
+    );
+
+    if (this.voter) {
+      const votePrompt =
+        'Choose the best response for the user question. ' +
+        'Return the number of the best answer.\n\nQuestion:' +
+        ` ${prompt}\n` +
+        this.clients
+          .map((c, i) => `Answer ${i}: ${responses[i]}`)
+          .join('\n');
+
+      const vote = await this.voter.generate(votePrompt);
+      const match = vote.match(/\d+/);
+      if (match) {
+        const idx = parseInt(match[0], 10);
+        if (!isNaN(idx) && idx >= 0 && idx < responses.length) {
+          return responses[idx];
+        }
+      }
+    }
+
+    // Fallback heuristic: choose longest response
+    let best = responses[0] || '';
+    for (const resp of responses) {
+      if (resp.length > best.length) best = resp;
+    }
+    return best;
+  }
+}
+

--- a/packages/core/src/core/openRouterClient.ts
+++ b/packages/core/src/core/openRouterClient.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LLMClient } from './multiModelClient.js';
+
+/** Simple client for calling models via OpenRouter. */
+export class OpenRouterClient implements LLMClient {
+  constructor(private apiKey: string, public name: string) {}
+
+  async generate(prompt: string): Promise<string> {
+    const body = {
+      model: this.name,
+      messages: [{ role: 'user', content: prompt }],
+    };
+
+    const resp = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const json = await resp.json();
+    return (
+      json.choices?.[0]?.message?.content || ''
+    ) as string;
+  }
+}
+

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,8 @@ export * from './config/config.js';
 
 // Export Core Logic
 export * from './core/client.js';
+export * from './core/multiModelClient.js';
+export * from './core/openRouterClient.js';
 export * from './core/contentGenerator.js';
 export * from './core/geminiChat.js';
 export * from './core/logger.js';


### PR DESCRIPTION
## Summary
- enable `models` array in config for multiple model names
- document OpenRouter API key and new `models` setting
- implement `MultiModelClient` and `OpenRouterClient`
- export clients in package entrypoints
- allow non-interactive CLI to use multi-model client
- add unit test for `MultiModelClient`

## Testing
- `npm install`
- `npm test` *(fails: Error: Failed to resolve entry for package `@google/gemini-cli-core`)*

------
https://chatgpt.com/codex/tasks/task_e_688068582dec832e9393c0f6f83079a2